### PR TITLE
res-md semantic asset: split type and format

### DIFF
--- a/schemas/xml/res-md.xsd
+++ b/schemas/xml/res-md.xsd
@@ -880,103 +880,411 @@
 
   <xs:complexType name="SemanticAsset">
     <xs:annotation>
-      <xs:documentation> a resource used to enable syntactic or semantic representation of
-        information </xs:documentation>
+      <xs:documentation>
+        a resource used to enable syntactic or semantic representation of
+        information
+      </xs:documentation>
     </xs:annotation>
 
     <xs:complexContent>
       <xs:extension base="rsm:ResourceRole">
         <xs:sequence>
-          <xs:element name="type" type="rsm:SemanticAssetRoleType" minOccurs="1"
-            maxOccurs="unbounded">
+
+          <xs:element name="involvesAssetType" type="rsm:SemanticAssetType" minOccurs="1"
+                      maxOccurs="unbounded">
             <xs:annotation>
               <xs:appinfo>
                 <label>Type</label>
               </xs:appinfo>
-              <xs:documentation> It is recommended that the pid attribute be set to
-                http://purl.org/dc/dcmitype/Dataset. </xs:documentation>
+              <xs:documentation>
+                a type of semantic asset that this resource includes or leverages
+              </xs:documentation>
             </xs:annotation>
           </xs:element>
+
+          <xs:element name="supportsFormat" type="rsm:SemanticAssetFileFormat" minOccurs="0"
+                      maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:appinfo>
+                <label>Type</label>
+              </xs:appinfo>
+              <xs:documentation>
+                a format for serializing semantic information that is used, provide, or
+                leveraged by this resource.  
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
 
-  <xs:simpleType name="SemanticAssetRoleType">
+  <xs:simpleType name="SemanticAssetType">
     <xs:annotation>
-      <xs:documentation> Controlled labels that indicate a type of role this resource can play as a
-        semantic asset. </xs:documentation>
+      <xs:documentation>
+        a type of semantic asset, as defined by a controlled list.
+      </xs:documentation>
     </xs:annotation>
 
     <xs:restriction base="xs:token">
 
-      <xs:enumeration value="Semantic Asset"><xs:annotation><xs:documentation>an unspecified semantic asset</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Code List"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Data Dictionary"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Data Model"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Data Type"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Dictionary"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: File Format"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Glossary"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Name Authority List"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: Common Logic"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: CycL"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: DAML+OIL"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: DOGMA"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: F-Logic"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: Gellish"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: KIF"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: KL-ONE"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: KM"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: LOOM"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: OCML"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: OIL"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: OKBC"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: OWL"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: PLIB"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: RACER"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: RDF"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: RDF Schema"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: SHOE"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Ontology: Turtle"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Reference Model"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: CAM"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: CLiX"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: DDML"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: DSD"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: DTD"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: HDF5-based"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: JSON Schema"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: JSON-based"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: JSON-LD"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: NRL"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: NVDL"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: RDF"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: RelaxNG"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: Schematron"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: SOX"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: WXS"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: XDR"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: XER"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: XML-based"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Schema: XSD"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Service Description"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Taxonomy"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Thesaurus"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: N-Quads"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: N-Triples"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: Notation3"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: RDF/JSON"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: RDF/XML"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: Sesame Binary RDF"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: SKOS"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: TriG"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: TriX"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: Turtle"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
-      <xs:enumeration value="Semantic Asset: Vocabulary: Zthes"><xs:annotation><xs:documentation>a semantic asset subtype identified by a RDA task group</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="Code List">
+        <xs:annotation>
+          <xs:documentation>
+            A controlled set of brief text strings that represent specific concepts
+          </xs:documentation>
+          <xs:documentation>
+            See UN Economic Commission for Europe, http://tfig.unece.org/contents/code-lists.htm
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="Data Dictionary">
+        <xs:annotation>
+          <xs:documentation>
+            A document that defines the meaning of tags, column names, or other markup
+            used to identify data values in a dataset.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Data Model">
+        <xs:annotation>
+          <xs:documentation>
+            A conceptual design for components of data set and their relationships to each other
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Data Type">
+        <xs:annotation>
+          <xs:documentation>
+            a definition for a category of data that constrains its components, possible values,
+            and (sometimes) representation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Dictionary">
+        <xs:annotation>
+          <xs:documentation>
+            a collection of associations of names or identifiers with values or meanings
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="File Format">
+        <xs:annotation>
+          <xs:documentation>
+            a specific definition of how data can be represented digitally as a stored object
+            in a manner that enables consistent machine-readability and machine-interpretation.  
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Glossary">
+        <xs:annotation>
+          <xs:documentation>
+            a resource for learning the semantic meaning of a vocabulary term or other symbol
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Name Authority List">
+        <xs:annotation>
+          <xs:documentation>
+            a collection of identifiers that map to organizations and other entities that have 
+            the authority to create identifiers within that organization's idenifier namespace.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology">
+        <xs:annotation>
+          <xs:documentation>
+            a formal definition of names for concepts and categories and their interrelationships
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology: DAML+OIL">
+        <xs:annotation>
+          <xs:documentation>
+            the DAML+OIL ontology definition language
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology: KIF">
+        <xs:annotation>
+          <xs:documentation>
+            The Knowledge Interchange Format (KIF) for expressing knowledge assertions
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology: OWL">
+        <xs:annotation>
+          <xs:documentation>
+            The Web Ontology Language (OWL) for authoring ontologies
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology: PLIB">
+        <xs:annotation>
+          <xs:documentation>
+            The PLIB (parts Libary) framework for mapping an ontology into a database model
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology: RDF">
+        <xs:annotation>
+          <xs:documentation>
+            the Resource Data Framework (RDF) describing the relationships between things and
+            their attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Ontology: RDF Schema">
+        <xs:annotation>
+          <xs:documentation>
+            The use of RDF Schema as a means for defining or constraining an ontology
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Reference Model">
+        <xs:annotation>
+          <xs:documentation>
+            a conceptual but detailed description of a system that can be used to implement examples
+            of such a system or to test a system for compliance to the description.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema">
+        <xs:annotation>
+          <xs:documentation>
+            a defined framework for structuring data in a common way for a particular purpose
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: DTD">
+        <xs:annotation>
+          <xs:documentation>
+            a Data Type Definition (DTD) document that identifies and constrains the XML markup 
+            used in an XML document
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: HDF5-based">
+        <xs:annotation>
+          <xs:documentation>
+            a defined profile of the HDF5 format that constains how to structure particular data
+            in an HDF5 dataset.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: JSON Schema">
+        <xs:annotation>
+          <xs:documentation>
+            a JSON Schema definition document that contrains the properties and structure of 
+            JSON-encoded data.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: JSON-based">
+        <xs:annotation>
+          <xs:documentation>
+            any (other) type of schema that constrains the properties and structure of JSON data
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: RDF Schema">
+        <xs:annotation>
+          <xs:documentation>
+            the RDF Schema framework for defining constraints on the representation of information
+            using RDF
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: RelaxNG">
+        <xs:annotation>
+          <xs:documentation>
+            the RelaxNG model and format for defining an XML schema
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: Schematron">
+        <xs:annotation>
+          <xs:documentation>
+            the Schematron model and format for defining an XML schema
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: XML-based">
+        <xs:annotation>
+          <xs:documentation>
+            any (other) type of schema that constrains the properties and structure of an XML document
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Schema: XSD">
+        <xs:annotation>
+          <xs:documentation>
+            the W3C XML Schema model and format for defining an XML schema
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Service Description">
+        <xs:annotation>
+          <xs:documentation>
+            a formal (i.e. machine-readable) or informal description of the use of a (web)
+            service that includes its supported operations, inputs, outputs, and other constraints.  
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Taxonomy">
+        <xs:annotation>
+          <xs:documentation>
+            a set of terms (usually without definitions) typically used for categorizing things
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Thesaurus">
+        <xs:annotation>
+          <xs:documentation>
+            a document or data collection that describes the relationships, equivalencies,
+            similarities, and differences between terms in different vocabularies.  
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Thesaurus: Zthes">
+        <xs:annotation>
+          <xs:documentation>
+            a thesaurus defined using the Zthes model or XML format
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Vocabulary">
+        <xs:annotation>
+          <xs:documentation>
+            a controlled list of terms for a particular subject area, often accompanied with semantic
+            definitions
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Vocabulary: SKOS">
+        <xs:annotation>
+          <xs:documentation>
+            a vocabulary defined with the Simple Knowledge Organization System (SKOS) 
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+      <xs:enumeration value="Vocabulary: Zthes">
+        <xs:annotation>
+          <xs:documentation>
+            a vocabulary defined using the Zthes model or XML format
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="SemanticAssetFileFormat">
+    <xs:annotation>
+      <xs:documentation>
+        a file format for encoding semantic information
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:restriction base="xs:token">
+
+      <xs:enumeration value="JSON">
+        <xs:annotation>
+          <xs:documentation>
+            JavaScript Object Notation as defined by IETF RFC8259 and described at
+            https://json.org/.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="JSON-LD">
+        <xs:annotation>
+          <xs:documentation>
+            JSON for Linked Data as defined by W3C and described at https://json-ld.org.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="N-Triples">
+        <xs:annotation>
+          <xs:documentation>
+            The N-Triples RDF serialization format as defined by W3C
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="N-Quads">
+        <xs:annotation>
+          <xs:documentation>
+            The N-Quads RDF serialization format as defined by W3C
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="RDF/JSON">
+        <xs:annotation>
+          <xs:documentation>
+            The RDF 1.1 JSON Alternative Serialization for RDF as defined by W3C
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="RDF/XML">
+        <xs:annotation>
+          <xs:documentation>
+            The RDF 1.1 XML Syntax for RDF as defined by W3C
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="Turtle">
+        <xs:annotation>
+          <xs:documentation>
+            The Terse RDF Triple Language (Turtle) format for RDF as defined by W3C
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="XML">
+        <xs:annotation>
+          <xs:documentation>
+            The eXtensible Markup Language (XML) information serialization format as defined by W3C
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
 
     </xs:restriction>
   </xs:simpleType>

--- a/schemas/xml/semantic-asset-types.txt
+++ b/schemas/xml/semantic-asset-types.txt
@@ -18,7 +18,6 @@ Semantic Asset: Name Authority List
 Semantic Asset: Ontology
 Semantic Asset: Ontology: DAML+OIL
 Semantic Asset: Ontology: KIF
-Semantic Asset: Ontology: OKBC
 Semantic Asset: Ontology: OWL
 Semantic Asset: Ontology: PLIB
 Semantic Asset: Ontology: RDF
@@ -30,7 +29,7 @@ Semantic Asset: Schema: DTD
 Semantic Asset: Schema: HDF5-based
 Semantic Asset: Schema: JSON Schema
 Semantic Asset: Schema: JSON-based
-Semantic Asset: Schema: RDFs
+Semantic Asset: Schema: RDF Schema
 Semantic Asset: Schema: RelaxNG
 Semantic Asset: Schema: Schematron
 Semantic Asset: Schema: XML-based
@@ -38,6 +37,7 @@ Semantic Asset: Schema: XSD
 Semantic Asset: Service Description
 Semantic Asset: Taxonomy
 Semantic Asset: Thesaurus
+Semantic Asset: Thesaurus: Zthes
 Semantic Asset: Vocabulary
 Semantic Asset: Vocabulary: SKOS
 Semantic Asset: Vocabulary: Zthes

--- a/schemas/xml/semantic-asset-types.txt
+++ b/schemas/xml/semantic-asset-types.txt
@@ -5,63 +5,39 @@ Semantic Asset: Data Model
 Semantic Asset: Data Type
 Semantic Asset: Dictionary
 Semantic Asset: File Format
+Semantic Asset: File Format: JSON
+Semantic Asset: File Format: JSON-LD
+Semantic Asset: File Format: N-Triples
+Semantic Asset: File Format: N-Quads
+Semantic Asset: File Format: RDF/XML
+Semantic Asset: File Format: RDF/JSON
+Semantic Asset: File Format: Turtle
+Semantic Asset: File Format: XML
 Semantic Asset: Glossary
 Semantic Asset: Name Authority List
 Semantic Asset: Ontology
-Semantic Asset: Ontology: Common Logic
-Semantic Asset: Ontology: CycL
 Semantic Asset: Ontology: DAML+OIL
-Semantic Asset: Ontology: DOGMA
-Semantic Asset: Ontology: F-Logic
-Semantic Asset: Ontology: Gellish
 Semantic Asset: Ontology: KIF
-Semantic Asset: Ontology: KL-ONE
-Semantic Asset: Ontology: KM
-Semantic Asset: Ontology: LOOM
-Semantic Asset: Ontology: OCML
-Semantic Asset: Ontology: OIL
 Semantic Asset: Ontology: OKBC
 Semantic Asset: Ontology: OWL
 Semantic Asset: Ontology: PLIB
-Semantic Asset: Ontology: RACER
 Semantic Asset: Ontology: RDF
 Semantic Asset: Ontology: RDF Schema
-Semantic Asset: Ontology: SHOE
 Semantic Asset: Ontology: Turtle
 Semantic Asset: Reference Model
 Semantic Asset: Schema
-Semantic Asset: Schema: CAM
-Semantic Asset: Schema: CLiX
-Semantic Asset: Schema: DDML
-Semantic Asset: Schema: DSD
 Semantic Asset: Schema: DTD
 Semantic Asset: Schema: HDF5-based
 Semantic Asset: Schema: JSON Schema
 Semantic Asset: Schema: JSON-based
-Semantic Asset: Schema: JSON-LD
-Semantic Asset: Schema: NRL
-Semantic Asset: Schema: NVDL
-Semantic Asset: Schema: RDF
+Semantic Asset: Schema: RDFs
 Semantic Asset: Schema: RelaxNG
 Semantic Asset: Schema: Schematron
-Semantic Asset: Schema: SOX
-Semantic Asset: Schema: WXS
-Semantic Asset: Schema: XDR
-Semantic Asset: Schema: XER
 Semantic Asset: Schema: XML-based
 Semantic Asset: Schema: XSD
 Semantic Asset: Service Description
 Semantic Asset: Taxonomy
 Semantic Asset: Thesaurus
 Semantic Asset: Vocabulary
-Semantic Asset: Vocabulary: N-Quads
-Semantic Asset: Vocabulary: N-Triples
-Semantic Asset: Vocabulary: Notation3
-Semantic Asset: Vocabulary: RDF/JSON
-Semantic Asset: Vocabulary: RDF/XML
-Semantic Asset: Vocabulary: Sesame Binary RDF
 Semantic Asset: Vocabulary: SKOS
-Semantic Asset: Vocabulary: TriG
-Semantic Asset: Vocabulary: TriX
-Semantic Asset: Vocabulary: Turtle
 Semantic Asset: Vocabulary: Zthes


### PR DESCRIPTION
This PR proposes a modification of  the definition of the new `SemanticAsset` resource role in the res-md XSD that splits the single type element into new elements that are specific to that role.  Specifically:
  *  the `<type>` element becomes `<involvesType>`
     * the controlled vocabulary allowed as values is reduced to smaller more commonly used list
  *  a new `<supportsType>` element is added
     *  the controlled vocabulary allowed as values drawn from original taxonomy list
  *  semantic definitions were provided for the elements and all enumerated values